### PR TITLE
Library no longer throws on importable level states

### DIFF
--- a/src/Group.cs
+++ b/src/Group.cs
@@ -14,43 +14,12 @@ public class Group : Entity
 	private List<Entity> items;
 	public IList<Entity> Items { get { return items;}}
 	
-	// We need to make sure only non fixed shapes, or certain specials are grouped.
-	// This function will throw an exception if that isn't the case.
-	private void checkGroupableEntity(Entity entity)
-	{
-		if (entity is Shape ||
-			entity is Van ||
-			entity is DinnerTable ||
-			entity is IBeam ||
-			entity is SpikeSet ||
-			entity is TextBox ||
-			entity is NonPlayerCharacter ||
-			entity is Chair ||
-			entity is Bottle ||
-			entity is Television ||
-			entity is Boombox ||
-			entity is Sign ||
-			entity is Toilet ||
-			entity is TrashCan ||
-			entity is ArrowGun ||
-			entity is Food ||
-			entity is BladeWeapon) 
-		{
-			return;
-		}
-		throw new LevelXMLException("{nameof(entity)} are not allowed in groups.");
-	}
-	
 	public override double X
 	{
 		get { return GetDoubleOrNull("x") ?? 0; }
 		set
 		{
-			if (double.IsNaN(value))
-			{
-				throw new LevelXMLException("This would make the group disappear!");
-			}
-			else { SetDouble("x", value); }
+			SetDouble("x", value);
 		}
 	}
 
@@ -59,11 +28,7 @@ public class Group : Entity
 		get { return GetDouble("y"); }
 		set
 		{
-			if (double.IsNaN(value))
-			{
-				throw new LevelXMLException("This would make the group disappear!");
-			}
-			else { SetDouble("y", value); }
+			SetDouble("y", value);
 		}
 	}
 
@@ -72,11 +37,7 @@ public class Group : Entity
 		get { return GetDouble("r"); }
 		set 
 		{ 
-			if (double.IsNaN(value))
-			{
-				throw new LevelXMLException("This would make the group disappear!");
-			}
-			else { SetDouble("r", value); }
+			SetDouble("r", value);
 		}
 	}
 
@@ -85,11 +46,7 @@ public class Group : Entity
 		get { return GetDouble("ox");}
 		set
 		{
-			if (double.IsNaN((double)value!))
-			{
-				throw new LevelXMLException("This would make the group disappear!");
-			}
-			else { SetDouble("ox", value); }
+			SetDouble("ox", value);
 		}
 	}
 
@@ -98,11 +55,7 @@ public class Group : Entity
 		get { return GetDouble("oy");}
 		set
 		{
-			if (double.IsNaN((double)value!))
-			{
-				throw new LevelXMLException("This would make the group disappear!");
-			}
-			else { SetDouble("oy", value); }
+			SetDouble("oy", value);
 		}
 	}
 
@@ -158,7 +111,6 @@ public class Group : Entity
 		Elt.RemoveNodes();
 		foreach (Entity entity in items)
 		{
-			checkGroupableEntity(entity);
 			entity.PlaceInLevel(mapper);
 			Elt.Add(entity.Elt);
 		}

--- a/src/Info.cs
+++ b/src/Info.cs
@@ -94,19 +94,15 @@ internal class Info : LevelXMLTag, IConvertibleToXML
 		}
 	}
 
-	internal double? E
+	internal double E
 	{
 		set
 		{
-			if (value != 1)
-			{
-				throw new LevelXMLException("This would make the level not import!");
-			}
-			Elt.SetAttributeValue("e", value!);
+			Elt.SetAttributeValue("e", value);
 		}
 	}
 
-	protected void setParams(XElement e)
+	protected void SetParams(XElement e)
 	{
 		Version = Info.LevelXMLVersion;
 		X = GetDoubleOrNull(e, "x") ?? double.NaN;
@@ -114,11 +110,9 @@ internal class Info : LevelXMLTag, IConvertibleToXML
 		Character = GetDoubleOrNull(e, "c") ?? double.NaN;
 		ForcedCharacter = GetBoolOrNull(e, "f") ?? false;
 		VehicleHidden = GetBoolOrNull(e, "h") ?? false;
-		Background = GetDoubleOrNull(e, "bg") ?? LevelXML.Background.Buggy;
+		Background = GetDoubleOrNull(e, "bg") ?? Background.Buggy;
 		BackgroundColor = GetDoubleOrNull(e, "bgc") ?? 16777215;
-		// Unfortunate naming here
-		// idk what Jim Bonacci meant by "e"
-		this.E = GetDoubleOrNull(e, "e");
+		E = 1;
 	}
 
 	public Info(string xml=EditorDefault) : this (StrToXElement(xml)) {}
@@ -126,6 +120,6 @@ internal class Info : LevelXMLTag, IConvertibleToXML
 	internal Info(XElement e) : base("info")
 	{
 		Elt = new XElement(e.Name.ToString());
-		setParams(e);
+		SetParams(e);
 	}
 }

--- a/src/Info.cs
+++ b/src/Info.cs
@@ -10,15 +10,6 @@ internal class Info : LevelXMLTag, IConvertibleToXML
 	internal const string LevelXMLVersion = "1.95";
 	public const string EditorDefault = @"<info v=""" + LevelXMLVersion + @""" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>";
 
-	internal string Version
-	{
-		get { return GetString("v"); }
-		set
-		{
-			Elt.SetAttributeValue("v", value);
-		}
-	}
-
 	public string ToXML() { return ToXML(mapper: default!); }
 
 	public double X
@@ -94,17 +85,9 @@ internal class Info : LevelXMLTag, IConvertibleToXML
 		}
 	}
 
-	internal double E
-	{
-		set
-		{
-			Elt.SetAttributeValue("e", value);
-		}
-	}
-
 	protected void SetParams(XElement e)
 	{
-		Version = Info.LevelXMLVersion;
+		Elt.SetAttributeValue("v", LevelXMLVersion);
 		X = GetDoubleOrNull(e, "x") ?? double.NaN;
 		Y = GetDoubleOrNull(e, "y") ?? double.NaN;
 		Character = GetDoubleOrNull(e, "c") ?? double.NaN;
@@ -112,7 +95,7 @@ internal class Info : LevelXMLTag, IConvertibleToXML
 		VehicleHidden = GetBoolOrNull(e, "h") ?? false;
 		Background = GetDoubleOrNull(e, "bg") ?? Background.Buggy;
 		BackgroundColor = GetDoubleOrNull(e, "bgc") ?? 16777215;
-		E = 1;
+		Elt.SetAttributeValue("e", 1);
 	}
 
 	public Info(string xml=EditorDefault) : this (StrToXElement(xml)) {}

--- a/src/Joint.cs
+++ b/src/Joint.cs
@@ -11,39 +11,6 @@ public abstract class Joint : Entity
 	private Entity? first;
 	private Entity? second;
 
-	private void checkIfCanBeJointed(Entity? entity)
-	{
-		string exceptionMessage = "Cannot joint a " + (entity ?? new Group()).GetType().Name;
-		if (entity is null || entity is Group) { return; }
-		if (entity is Shape shape)
-		{
-			if (shape is Art) {  throw new LevelXMLException(exceptionMessage); }
-			return;
-		}
-		if (entity is Group) { return; }
-		if (entity is Special special)
-		{
-			if (special is IBeam) { return; }
-			if (special is Log) { return; }
-			if (special is ArrowGun) { return; }
-			if (special is SpikeSet) { return; }
-			if (special is Jet) { return; }
-			if (special is NonPlayerCharacter) { return; }
-			if (special is BladeWeapon) { return; }
-			if (special is Food) { return; }
-			if (special is Chain) { return; }
-			if (special is GlassPanel) { return; }
-			if (special is DinnerTable) { return; }
-			if (special is Chair) { return; }
-			if (special is Bottle) { return; }
-			if (special is Television) { return; }
-			if (special is Boombox) { return; }
-			if (special is Van) { return; }
-			if (special is TrashCan) { return; }
-			if (special is Toilet) { return; }
-		}
-		throw new LevelXMLException(exceptionMessage);
-	}
 	/// <summary>
 	///  The first Entity this Joint is jointed to.
 	///  Null means it's jointed to the background.
@@ -53,7 +20,6 @@ public abstract class Joint : Entity
 		get { return first;}
 		set
 		{
-			checkIfCanBeJointed(value);
 			first = value;
 		}
 	}
@@ -67,7 +33,6 @@ public abstract class Joint : Entity
 		get { return second;}
 		set
 		{
-			checkIfCanBeJointed(value);
 			second = value;
 		}
 	}

--- a/src/Joints/SlidingJoint.cs
+++ b/src/Joints/SlidingJoint.cs
@@ -54,10 +54,6 @@ public class SlidingJoint : Joint
         get { return GetDoubleOrNull("a") ?? double.NaN; }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the angle to NaN on a sliding joint makes a black hole!");
-            }
             SetDouble("a", value);
         }
     }

--- a/src/Level.cs
+++ b/src/Level.cs
@@ -244,7 +244,7 @@ public class Level : LevelXMLTag, IConvertibleToXML
 	{
 		if (e.Name.ToString() != "levelXML")
 		{
-			throw new LevelXMLException("You didn't give me a LevelXML tag!");
+			throw new LevelXMLException("Xml is missing a LevelXML Tag!");
 		}
 		XElement? InfoTag = e.Element("info");
 		if (InfoTag is null) { 

--- a/src/LevelXML.csproj
+++ b/src/LevelXML.csproj
@@ -21,7 +21,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/ultrako/LevelXML</RepositoryUrl> 

--- a/src/Shape.cs
+++ b/src/Shape.cs
@@ -146,10 +146,6 @@ public abstract class Shape : Entity
 	// Had to split this out into two because the order of setting these properties matters
 	protected void SetFirstParams(XElement e)
 	{
-		if (e.Name != "sh")
-		{
-			throw new LevelXMLException("Shape xml string was not passed to the Shape constructor!");
-		}
 		Elt.SetAttributeValue("t", Type);
 		Interactive = GetBoolOrNull(e, "i");
         X = GetDoubleOrNull(e, "p0") ?? double.NaN;

--- a/src/Shape.cs
+++ b/src/Shape.cs
@@ -35,11 +35,7 @@ public abstract class Shape : Entity
 		get { return GetDouble("p0"); }
 		set
 		{
-			if (double.IsNaN(value))
-			{
-				throw new LevelXMLException("This would make the shape disappear!");
-			}
-			else { Elt.SetAttributeValue("p0", value); }
+			Elt.SetAttributeValue("p0", value);
 		}
 	}
 	public override double Y
@@ -47,11 +43,7 @@ public abstract class Shape : Entity
 		get { return GetDouble("p1"); }
 		set
 		{
-			if (double.IsNaN(value))
-			{
-				throw new LevelXMLException("This would make the shape disappear!");
-			}
-			else { Elt.SetAttributeValue("p1", value); }
+			Elt.SetAttributeValue("p1", value);
 		}
 	}
 
@@ -65,10 +57,6 @@ public abstract class Shape : Entity
 		get { return GetDouble("p4"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the shape disappear!");
-			}
 			Elt.SetAttributeValue("p4", Math.Clamp(value,-180,180)); 
 		}
 	}
@@ -158,6 +146,10 @@ public abstract class Shape : Entity
 	// Had to split this out into two because the order of setting these properties matters
 	protected void SetFirstParams(XElement e)
 	{
+		if (e.Name != "sh")
+		{
+			throw new LevelXMLException("Shape xml string was not passed to the Shape constructor!");
+		}
 		Elt.SetAttributeValue("t", Type);
 		Interactive = GetBoolOrNull(e, "i");
         X = GetDoubleOrNull(e, "p0") ?? double.NaN;

--- a/src/Shapes/Circle.cs
+++ b/src/Shapes/Circle.cs
@@ -15,9 +15,6 @@ public class Circle : Shape, IConvertibleToXML
 		get { return GetDouble("p2"); }
 		set
 		{
-			if (double.IsNaN(value)) {
-				throw new LevelXMLException("This would make the circle disappear!");
-			}
             double clamped = Math.Clamp(value, 5, 5000);
 			Elt.SetAttributeValue("p2", clamped);
             Elt.SetAttributeValue("p3", clamped);

--- a/src/Shapes/CustomShape.cs
+++ b/src/Shapes/CustomShape.cs
@@ -6,7 +6,7 @@ namespace LevelXML;
 /// </summary>
 public abstract class CustomShape : Shape
 {
-	private Vertices verticesTag;
+	private readonly Vertices verticesTag;
 	internal CustomShape CopiedShape;
 	internal bool isEmpty;
 	internal int originalIndex;
@@ -16,8 +16,6 @@ public abstract class CustomShape : Shape
 	}
 	public override double Width
 	{
-		// Either figure out a way to get the width from the vertices,
-		// or make this field nullable
 		get 
 		{
 			return GetDouble("p2");

--- a/src/Shapes/Rectangle.cs
+++ b/src/Shapes/Rectangle.cs
@@ -18,10 +18,6 @@ public class Rectangle : Shape, IConvertibleToXML
 		get { return GetDouble("p2");}
 		set
 		{
-			if (double.IsNaN(value)) 
-			{
-                throw new LevelXMLException("This would make the rectangle disappear!");
-			} 
 			SetDouble("p2", Math.Clamp(value, 5, 5000));
 		}
 	}
@@ -31,9 +27,6 @@ public class Rectangle : Shape, IConvertibleToXML
 		get { return GetDouble("p3"); }
 		set
 		{
-			if (double.IsNaN(value)) {
-				throw new LevelXMLException("This would make the rectangle disappear!");
-			} 
 			SetDouble("p3", Math.Clamp(value, 5, 5000));
 		}
 	}

--- a/src/Shapes/Triangle.cs
+++ b/src/Shapes/Triangle.cs
@@ -18,22 +18,18 @@ public class Triangle : Shape, IConvertibleToXML
 		get { return GetDouble("p2"); }
 		set
 		{
-			if (double.IsNaN(value)) 
-			{
-                throw new LevelXMLException("This would make the triangle disappear!");
-			} 
+
 			SetDouble("p2", Math.Clamp(value, 5, 5000));
 		}
 	}
 
+	// Should I consider clamping height based on Width?
+	// Or should I just let the game do that for me?
 	public override double Height
 	{
 		get { return GetDouble("p3"); }
 		set
 		{
-			if (double.IsNaN(value)) {
-				throw new LevelXMLException("This would make the triangle disappear!");
-			} 
 			SetDouble("p3", Math.Clamp(value, 15, 5000));
 		}
 	}

--- a/src/Special.cs
+++ b/src/Special.cs
@@ -16,11 +16,7 @@ public abstract class Special : Entity, IConvertibleToXML
 		get { return GetDouble("p0"); }
 		set
 		{
-			if (double.IsNaN(value))
-			{
-				throw new LevelXMLException("This would make the special disappear!");
-			}
-			else { Elt.SetAttributeValue("p0", value); }
+			Elt.SetAttributeValue("p0", value);
 		}
 	}
 
@@ -29,11 +25,7 @@ public abstract class Special : Entity, IConvertibleToXML
 		get { return GetDouble("p1"); }
 		set
 		{
-			if (double.IsNaN(value))
-			{
-				throw new LevelXMLException("This would make the special disappear!");
-			}
-			else { Elt.SetAttributeValue("p1", value); }
+			Elt.SetAttributeValue("p1", value);
 		}
 	}
 

--- a/src/Specials/ArrowGun.cs
+++ b/src/Specials/ArrowGun.cs
@@ -13,10 +13,6 @@ public class ArrowGun : Special
 		get { return GetDouble("p2"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/BladeWeapon.cs
+++ b/src/Specials/BladeWeapon.cs
@@ -13,10 +13,6 @@ public class BladeWeapon : Special
 		get { return GetDouble("p2"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/BoomBox.cs
+++ b/src/Specials/BoomBox.cs
@@ -13,10 +13,6 @@ public class Boombox : Special
 		get { return GetDouble("p2"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Boost.cs
+++ b/src/Specials/Boost.cs
@@ -13,10 +13,6 @@ public class Boost : Special
 		get { return GetDouble("p2"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
 			SetDouble("p2", value); 
 		}
 	}
@@ -29,11 +25,7 @@ public class Boost : Special
 	{
 		get { return GetDouble("p3"); }
 		set 
-        { 
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("That would make the boost disappear!");
-            }
+        {
             Elt.SetAttributeValue("p3", Math.Clamp(value, 1, 6)); 
         }
 	}

--- a/src/Specials/Bottle.cs
+++ b/src/Specials/Bottle.cs
@@ -13,10 +13,6 @@ public class Bottle : Special
 		get { return GetDouble("p2"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Building.cs
+++ b/src/Specials/Building.cs
@@ -11,11 +11,7 @@ public abstract class Building : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", Math.Clamp(value, 1, 10)); 
 		}
 	}

--- a/src/Specials/Cannon.cs
+++ b/src/Specials/Cannon.cs
@@ -13,10 +13,6 @@ public class Cannon : Special
 		get { return GetDouble("p2"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
 			SetDouble("p2", value); 
 		}
 	}
@@ -81,7 +77,7 @@ public class Cannon : Special
         Rotation = GetDoubleOrNull(e, "p2") ?? 0;
         StartRotation = GetDoubleOrNull(e, "p3") ?? 0;
         FiringRotation = GetDoubleOrNull(e, "p4") ?? 0;
-        CannonType = GetDoubleOrNull(e, "p5") ?? LevelXML.CannonType.Circus;
+        CannonType = GetDoubleOrNull(e, "p5") ?? CannonType.Circus;
         Delay = GetDoubleOrNull(e, "p6") ?? 1;
         MuzzleScale = GetDoubleOrNull(e, "p7") ?? 1;
         Power = GetDoubleOrNull(e, "p8") ?? 5;

--- a/src/Specials/Chain.cs
+++ b/src/Specials/Chain.cs
@@ -12,11 +12,7 @@ public class Chain : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}
@@ -50,10 +46,6 @@ public class Chain : Special
         get { return GetDouble("p6"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the Link Scale to NaN would make the chain disappear!");
-            }
             SetDouble("p6", Math.Clamp(value, 1, 10));
         }
     }
@@ -66,10 +58,6 @@ public class Chain : Special
         get { return GetDouble("p7"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the Curve to NaN would make the chain disappear!");
-            }
             SetDouble("p7", Math.Clamp(value, -10, 10));
         }
     }

--- a/src/Specials/Chair.cs
+++ b/src/Specials/Chair.cs
@@ -13,10 +13,6 @@ public class Chair : Special
 		get { return GetDouble("p2"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/DinnerTable.cs
+++ b/src/Specials/DinnerTable.cs
@@ -12,11 +12,7 @@ public class DinnerTable : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Fan.cs
+++ b/src/Specials/Fan.cs
@@ -12,11 +12,7 @@ public class Fan : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Food.cs
+++ b/src/Specials/Food.cs
@@ -12,11 +12,7 @@ public class Food : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/GlassPanel.cs
+++ b/src/Specials/GlassPanel.cs
@@ -13,10 +13,6 @@ public class GlassPanel : Special
         get { return GetDouble("p2"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the width to NaN would make this glass panel disappear!");
-            }
             SetDouble("p2", Math.Clamp(value, 5, 50));
         }
     }
@@ -26,10 +22,6 @@ public class GlassPanel : Special
         get { return GetDouble("p3"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the height to NaN would make this glass panel disappear!");
-            }
             SetDouble("p3", Math.Clamp(value, 50, 500));
         }
     }
@@ -38,11 +30,7 @@ public class GlassPanel : Special
 	{
 		get { return GetDouble("p4"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p4", value); 
 		}
 	}

--- a/src/Specials/Harpoon.cs
+++ b/src/Specials/Harpoon.cs
@@ -12,11 +12,7 @@ public class Harpoon : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/IBeam.cs
+++ b/src/Specials/IBeam.cs
@@ -13,10 +13,6 @@ public class IBeam : Special
         get { return GetDouble("p2"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the width to NaN would make the special disappear!");
-            }
             SetDouble("p2", Math.Clamp(value, 200, 1600));
         }
     }
@@ -26,10 +22,6 @@ public class IBeam : Special
         get { return GetDouble("p3"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the height to NaN would make the special disappear!");
-            }
             SetDouble("p3", Math.Clamp(value, 32, 64));
         }
     }
@@ -38,11 +30,7 @@ public class IBeam : Special
 	{
 		get { return GetDouble("p4"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("Setting the rotation to NaN would make the special disappear!");
-			}
+		{
 			SetDouble("p4", value); 
 		}
 	}

--- a/src/Specials/Jet.cs
+++ b/src/Specials/Jet.cs
@@ -12,11 +12,7 @@ public class Jet : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}
@@ -35,10 +31,6 @@ public class Jet : Special
         get { return GetDouble("p4"); }
         set 
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the power to NaN would make the jet disappear!");
-            }
             SetDouble("p4", Math.Clamp(value, 1, 10));
         }
     }

--- a/src/Specials/LandMine.cs
+++ b/src/Specials/LandMine.cs
@@ -12,11 +12,7 @@ public class Landmine : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Log.cs
+++ b/src/Specials/Log.cs
@@ -13,10 +13,6 @@ public class Log : Special
         get { return GetDouble("p2"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the width to NaN would make the special disappear!");
-            }
             SetDouble("p2", Math.Clamp(value, 36, 54));
         }
     }
@@ -26,10 +22,6 @@ public class Log : Special
         get { return GetDouble("p3"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the height to NaN would make the special disappear!");
-            }
             SetDouble("p3", Math.Clamp(value, 200, 600));
         }
     }
@@ -38,11 +30,7 @@ public class Log : Special
 	{
 		get { return GetDoubleOrNull("p4") ?? 0; }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("Setting the rotation to NaN would make the special disappear!");
-			}
+		{
 			SetDouble("p4", value); 
 		}
 	}

--- a/src/Specials/Meteor.cs
+++ b/src/Specials/Meteor.cs
@@ -13,10 +13,6 @@ public class Meteor : Special
         get { return GetDouble("p2"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the width or height to NaN would make the special disappear!");
-            }
             double clamped = Math.Clamp(value, 200, 600);
             SetDouble("p2", clamped);
             SetDouble("p3", clamped);

--- a/src/Specials/NonPlayerCharacter.cs
+++ b/src/Specials/NonPlayerCharacter.cs
@@ -13,10 +13,6 @@ public class NonPlayerCharacter : Special
 		get { return GetDouble("p2"); }
 		set 
 		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
 			SetDouble("p2", value); 
 		}
 	}
@@ -65,10 +61,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p8"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p8", Math.Clamp(value, -20, 20));
         }
     }
@@ -78,10 +70,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p9"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p9", Math.Clamp(value, -180, 60));
         }
     }
@@ -91,10 +79,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p10"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p10", Math.Clamp(value, -180, 60));
         }
     }
@@ -104,10 +88,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p11"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p11", Math.Clamp(value, -160, 0));
         }
     }
@@ -117,10 +97,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p12"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p12", Math.Clamp(value, -160, 0));
         }
     }
@@ -130,10 +106,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p13"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p13", Math.Clamp(value, -160, 10));
         }
     }
@@ -143,10 +115,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p14"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p14", Math.Clamp(value, -160, 10));
         }
     }
@@ -156,10 +124,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p15"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p15", Math.Clamp(value, -0, 150));
         }
     }
@@ -169,10 +133,6 @@ public class NonPlayerCharacter : Special
         get { return GetDouble("p16"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting any pose angle to NaN would make this NPC disappear!");
-            }
             SetDouble("p16", Math.Clamp(value, -0, 150));
         }
     }
@@ -190,7 +150,7 @@ public class NonPlayerCharacter : Special
     {
         base.SetParams(e);
         Rotation = GetDoubleOrNull(e, "p2") ?? 0;
-        NPCType = GetDoubleOrNull(e, "p3") ?? LevelXML.NPCType.WheelchairGuy;
+        NPCType = GetDoubleOrNull(e, "p3") ?? NPCType.WheelchairGuy;
         Sleeping = GetBoolOrNull(e, "p4") ?? false;
         Reverse = GetBoolOrNull(e, "p5") ?? false;
         HoldPose = GetBoolOrNull(e, "p6") ?? false;

--- a/src/Specials/PaddlePlatform.cs
+++ b/src/Specials/PaddlePlatform.cs
@@ -12,11 +12,7 @@ public class PaddlePlatform : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Rail.cs
+++ b/src/Specials/Rail.cs
@@ -13,10 +13,6 @@ public class Rail : Special
         get { return GetDouble("p2"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the width to NaN would make the special disappear!");
-            }
             SetDouble("p2", Math.Clamp(value, 100, 2000));
         }
     }
@@ -26,10 +22,6 @@ public class Rail : Special
         get { return GetDouble("p3"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the height to NaN would make the special disappear!");
-            }
             SetDouble("p3", Math.Clamp(value, 18, 18));
         }
     }
@@ -38,11 +30,7 @@ public class Rail : Special
 	{
 		get { return GetDouble("p4"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("Setting the rotation to NaN would make the special disappear!");
-			}
+		{
 			SetDouble("p4", value); 
 		}
 	}

--- a/src/Specials/Sign.cs
+++ b/src/Specials/Sign.cs
@@ -12,11 +12,7 @@ public class Sign : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}
@@ -37,7 +33,7 @@ public class Sign : Special
     {
         base.SetParams(e);
         Rotation = GetDoubleOrNull(e, "p2") ?? 0;
-        SignType = GetDoubleOrNull(e, "p3") ?? LevelXML.SignType.RightArrow;
+        SignType = GetDoubleOrNull(e, "p3") ?? SignType.RightArrow;
         ShowSignPost = GetBoolOrNull(e, "p4") ?? true;
     }
 

--- a/src/Specials/SpikeSet.cs
+++ b/src/Specials/SpikeSet.cs
@@ -13,11 +13,7 @@ public class SpikeSet : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("Setting the rotation to NaN would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}
@@ -36,10 +32,6 @@ public class SpikeSet : Special
         get { return GetDouble("p4"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the number of spikes to NaN would cause the spike set to disappear!");
-            }
             SetDouble("p4", value);
         }
     }

--- a/src/Specials/SpringPlatform.cs
+++ b/src/Specials/SpringPlatform.cs
@@ -13,10 +13,6 @@ public class SpringPlatform : Special
         get { return GetDouble("p2"); }
         set
         {
-            if (double.IsNaN(value))
-            {
-                throw new LevelXMLException("Setting the rotation to NaN would make the special disappear!");
-            }
             SetDouble("p2", value);
         }
     }

--- a/src/Specials/Television.cs
+++ b/src/Specials/Television.cs
@@ -12,11 +12,7 @@ public class Television : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/TextBox.cs
+++ b/src/Specials/TextBox.cs
@@ -17,11 +17,7 @@ public class TextBox : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the text box disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Toilet.cs
+++ b/src/Specials/Toilet.cs
@@ -12,11 +12,7 @@ public class Toilet : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Token.cs
+++ b/src/Specials/Token.cs
@@ -17,7 +17,7 @@ public class Token : Special
     protected override void SetParams(XElement e)
     {
         base.SetParams(e);
-        TokenType = GetDoubleOrNull(e, "p2") ?? LevelXML.TokenType.Skull;
+        TokenType = GetDoubleOrNull(e, "p2") ?? TokenType.Skull;
     }
 
     public Token(string xml=EditorDefault) : this(StrToXElement(xml)) {}

--- a/src/Specials/TrashCan.cs
+++ b/src/Specials/TrashCan.cs
@@ -12,11 +12,7 @@ public class TrashCan : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Specials/Van.cs
+++ b/src/Specials/Van.cs
@@ -12,11 +12,7 @@ public class Van : Special
 	{
 		get { return GetDouble("p2"); }
 		set 
-		{ 
-			if (double.IsNaN(value)) 
-			{
-				throw new LevelXMLException("That would make the special disappear!");
-			}
+		{
 			SetDouble("p2", value); 
 		}
 	}

--- a/src/Structs/BottleType.cs
+++ b/src/Structs/BottleType.cs
@@ -10,13 +10,10 @@ public struct BottleType
     public static readonly BottleType Blue = 2;
     public static readonly BottleType Red = 3;
     public static readonly BottleType Yellow = 4;
+    public static readonly BottleType None = double.NaN;
 
     private BottleType(double val)
     {
-        if (double.IsNaN(val))
-        {
-            throw new LevelXMLException("This would make the level freeze on start!");
-        }
         this.val = Math.Clamp(val, 1, 4);
     }
     public static implicit operator BottleType(double val)

--- a/src/Structs/Character.cs
+++ b/src/Structs/Character.cs
@@ -17,13 +17,10 @@ public struct Character
     public static readonly Character PogostickMan = 9;
     public static readonly Character IrresponsibleMom = 10;
     public static readonly Character HelicopterMan = 11;
+    public static readonly Character None = double.NaN;
 
     private Character(double val)
     {
-        if (double.IsNaN(val))
-        {
-            throw new LevelXMLException("This would make the level freeze at start!");
-        }
         this.val = Math.Clamp(val, 1, 11);
     }
     public static implicit operator Character(double val)

--- a/src/Structs/FoodType.cs
+++ b/src/Structs/FoodType.cs
@@ -9,13 +9,10 @@ public struct FoodType
     public static readonly FoodType Watermelon = 1;
     public static readonly FoodType Pumpkin = 2;
     public static readonly FoodType Pineapple = 3;
+    public static readonly FoodType None = double.NaN;
 
     private FoodType(double val)
     {
-        if (double.IsNaN(val))
-        {
-            throw new LevelXMLException("This would make the food disappear!");
-        }
         this.val = Math.Clamp(val, 1, 3);
     }
     public static implicit operator FoodType(double val)

--- a/src/Structs/NPCType.cs
+++ b/src/Structs/NPCType.cs
@@ -25,6 +25,8 @@ public struct NPCType
 
     private NPCType(double val)
     {
+        // Yes, it specifically no longer stays in the LevelXML in import,
+        // if I don't throw here it's hard to debug
         if (double.IsNaN(val))
         {
             throw new LevelXMLException("This would make the NPC disappear!");

--- a/src/Structs/TokenType.cs
+++ b/src/Structs/TokenType.cs
@@ -12,13 +12,10 @@ public struct TokenType
     public static readonly TokenType Axe = 4;
     public static readonly TokenType Bowling = 5;
     public static readonly TokenType Peace = 6;
+    public static readonly TokenType HalfToken = double.NaN;
 
     private TokenType(double val)
     {
-        if (double.IsNaN(val))
-        {
-            throw new LevelXMLException("This would make the token disappear!");
-        }
         this.val = Math.Clamp(val, 1, 6);
     }
     public static implicit operator TokenType(double val)

--- a/src/Structs/WeaponType.cs
+++ b/src/Structs/WeaponType.cs
@@ -18,13 +18,10 @@ public struct WeaponType
     public static readonly WeaponType Javelin = 10;
     public static readonly WeaponType Sai = 11;
     public static readonly WeaponType Trident = 12;
+    public static readonly WeaponType Invisible = double.NaN;
 
     private WeaponType(double val)
     {
-        if (double.IsNaN(val))
-        {
-            throw new LevelXMLException("That would make the blade weapon disappear!");
-        }
         this.val = Math.Clamp(val, 1, 12);
     }
     public static implicit operator WeaponType(double val)

--- a/src/Target.cs
+++ b/src/Target.cs
@@ -75,7 +75,8 @@ public abstract class Target : LevelXMLTag
 				Food => new Target<Food>(e, ReverseTargetMapper),
 				Bottle => new Target<Bottle>(e, ReverseTargetMapper),
 				Meteor => new Target<Meteor>(e, ReverseTargetMapper),
-				_ => throw new LevelXMLException("Special type cannot be pointed to by a trigger!"),
+				Special => new Target<Special>(e, ReverseTargetMapper),
+				_ => throw new LevelXMLException("Invalid special type pointed to by trigger!")
 			},
 			"g" => new Target<Group>(e, ReverseTargetMapper),
 			"j" => new Target<Joint>(e, ReverseTargetMapper),

--- a/src/TriggerAction.cs
+++ b/src/TriggerAction.cs
@@ -36,7 +36,7 @@ public interface ITriggerAction<in T> : ITriggerAction
 				5 => (new DeleteShapes<Shape>() as ITriggerAction<T>)!,
 				6 => (new DeleteSelf<Shape>() as ITriggerAction<T>)!,
 				7 => (new ChangeCollision<Shape>(element) as ITriggerAction<T>)!,
-				_ => throw new LevelXMLException("Invalid id for an action targeting a shape!"),
+				_ => (new AwakeFromSleep<Shape>() as ITriggerAction<T>)!,
 			},
 			nameof(Group) => ActionType switch
 			{
@@ -48,7 +48,7 @@ public interface ITriggerAction<in T> : ITriggerAction
 				5 => (new DeleteShapes<Group>() as ITriggerAction<T>)!,
 				6 => (new DeleteSelf<Group>() as ITriggerAction<T>)!,
 				7 => (new ChangeCollision<Group>(element) as ITriggerAction<T>)!,
-				_ => throw new LevelXMLException("Invalid id for an action targeting a group!"),
+				_ => (new AwakeFromSleep<Group>() as ITriggerAction<T>)!,
 			},
 			nameof(Joint) => ActionType switch
 			{
@@ -57,21 +57,21 @@ public interface ITriggerAction<in T> : ITriggerAction
 				2 => (new DeleteSelfJoint() as ITriggerAction<T>)!,
 				3 => (new DisableLimits() as ITriggerAction<T>)!,
 				4 => (new ChangeLimits(element) as ITriggerAction<T>)!,
-				_ => throw new LevelXMLException("Invalid id for an action targeting a joint!"),
+				_ => (new DisableMotor() as ITriggerAction<T>)!,
 			},
 			nameof(Trigger) => ActionType switch 
 			{
 				0 => (new Activate() as ITriggerAction<T>)!,
 				1 => (new Disable() as ITriggerAction<T>)!,
 				2 => (new Enable() as ITriggerAction<T>)!,
-				_ => throw new LevelXMLException("Invalid id for an action targeting a trigger!"),
+				_ => (new Activate() as ITriggerAction<T>)!,
 			},
 			nameof(Harpoon) => ActionType switch
 			{
 				0 => (new FireHarpoon() as ITriggerAction<T>)!,
 				1 => (new DeactivateHarpoon() as ITriggerAction<T>)!,
 				2 => (new ActivateHarpoon() as ITriggerAction<T>)!,
-				_ => throw new LevelXMLException("Invalid id for an action targeting a harpoon!"),
+				_ => (new FireHarpoon() as ITriggerAction<T>)!,
 			},
 			nameof(Rail) or 
 			nameof(SpikeSet) or
@@ -90,13 +90,13 @@ public interface ITriggerAction<in T> : ITriggerAction
 			{
 				0 => new AwakeFromSleep<T>(),
 				1 => new Impulse<T>(),
-				_ => throw new LevelXMLException("Invalid id for an action")
+				_ => new AwakeFromSleep<T>()
 			},
 			nameof(TextBox) => ActionType switch
 			{
 				0 => (new ChangeOpacity<TextBox>(element) as ITriggerAction<T>)!,
 				1 => (new Slide(element) as ITriggerAction<T>)!,
-				_ => throw new LevelXMLException("Invalid id for an action targeting a textbox!"),
+				_ => (new ChangeOpacity<TextBox>(element) as ITriggerAction<T>)!,
 			},
 			nameof(NonPlayerCharacter) => ActionType switch
 			{
@@ -104,14 +104,14 @@ public interface ITriggerAction<in T> : ITriggerAction
 				1 => (new Impulse<NonPlayerCharacter>(element) as ITriggerAction<T>)!,
 				2 => (new HoldPose() as ITriggerAction<T>)!,
 				3 => (new ReleasePose() as ITriggerAction<T>)!,
-				_ => throw new LevelXMLException("Invalid id for an action targeting an NPC!"),
+				_ => (new AwakeFromSleep<NonPlayerCharacter>() as ITriggerAction<T>)!,
 			},
 			nameof(GlassPanel) => ActionType switch
 			{
 				0 => (new Shatter() as ITriggerAction<T>)!,
 				1 => (new AwakeFromSleep<GlassPanel>() as ITriggerAction<T>)!,
 				2 => (new Impulse<GlassPanel>(element) as ITriggerAction<T>)!,
-				_ => throw new LevelXMLException("Invalid id for an action targeting a glass panel!"),
+				_ => (new Shatter() as ITriggerAction<T>)!,
 			},
 			_ => throw new LevelXMLException($"Entity type {typeof(T).Name} cannot have trigger actions!"),
 		};

--- a/src/Triggers/SoundTrigger.cs
+++ b/src/Triggers/SoundTrigger.cs
@@ -1,5 +1,4 @@
 using System.Xml.Linq;
-using System.Collections;
 
 namespace LevelXML;
 /// <summary>
@@ -21,10 +20,6 @@ public class SoundTrigger : Trigger, IConvertibleToXML
 		get { return GetDoubleOrNull("s") ?? 0; }
 		set
 		{
-			if (value < 0 || value > 325)
-			{
-				throw new LevelXMLException("Sound number is invalid! This trigger would freeze the level!");
-			}
 			SetDouble("s", value);
 		}
 	}

--- a/tests/GroupTest.cs
+++ b/tests/GroupTest.cs
@@ -38,11 +38,10 @@ public class GroupTest
     }
 
     [Fact]
-    public void GroupWithJointThrows()
+    public void GroupWithJoint()
     {
         PinJoint joint = new();
         Group group = new(joint);
-        Assert.Throws<LevelXMLException>(() => group.ToXML(mapper:default!));
     }
 
     [Fact]
@@ -90,32 +89,32 @@ public class GroupTest
     }
 
     [Fact]
-    public void TestNaNXThrows()
+    public void TestNaNX()
     {
-        Assert.Throws<LevelXMLException>(() => new Group(@"<g x=""NaN"" y=""0"" r=""0"" ox=""0"" oy=""0"" />"));
+        _ = new Group(@"<g x=""NaN"" y=""0"" r=""0"" ox=""0"" oy=""0"" />");
     }
 
     [Fact]
-    public void TestNaNYThrows()
+    public void TestNaNY()
     {
-        Assert.Throws<LevelXMLException>(() => new Group(@"<g x=""0"" y=""NaN"" r=""0"" ox=""0"" oy=""0"" />"));
+       _ = new Group(@"<g x=""0"" y=""NaN"" r=""0"" ox=""0"" oy=""0"" />");
     }
 
     [Fact]
-    public void TestNaNRotationThrows()
+    public void TestNaNRotation()
     {
-        Assert.Throws<LevelXMLException>(() => new Group(@"<g x=""0"" y=""0"" r=""NaN"" ox=""0"" oy=""0"" />"));
+        _ = new Group(@"<g x=""0"" y=""0"" r=""NaN"" ox=""0"" oy=""0"" />");
     }
 
     [Fact]
-    public void TestNaNOriginXThrows()
+    public void TestNaNOriginX()
     {
-        Assert.Throws<LevelXMLException>(() => new Group(@"<g x=""0"" y=""0"" r=""0"" ox=""NaN"" oy=""0"" />"));
+        _ = new Group(@"<g x=""0"" y=""0"" r=""0"" ox=""NaN"" oy=""0"" />");
     }
 
     [Fact]
-    public void TestNaNOriginYThrows()
+    public void TestNaNOriginY()
     {
-        Assert.Throws<LevelXMLException>(() => new Group(@"<g x=""0"" y=""0"" r=""0"" ox=""0"" oy=""NaN"" />"));
+        _ = new Group(@"<g x=""0"" y=""0"" r=""0"" ox=""0"" oy=""NaN"" />");
     }
 }

--- a/tests/InfoTest.cs
+++ b/tests/InfoTest.cs
@@ -41,7 +41,6 @@ public class InfoTest
 	public void TestDefaultValues()
 	{
 		Info info = new();
-		Assert.Equal(Info.LevelXMLVersion, info.Version);
 		Assert.Equal(300, info.X);
 		Assert.Equal(5100, info.Y);
 	}

--- a/tests/JointTest.cs
+++ b/tests/JointTest.cs
@@ -109,7 +109,7 @@ public class JointTest
     public void SlidingJointNaNAngle()
     {
         SlidingJoint sj = new();
-        Assert.Throws<LevelXMLException>(() => sj.Angle = double.NaN);
+        sj.Angle = double.NaN;
     }
 
     [Fact]

--- a/tests/LevelTest.cs
+++ b/tests/LevelTest.cs
@@ -1565,7 +1565,7 @@ public class LevelTest
 	[Fact]
 	public void ParseLevelWithJointToSoccerBall()
 	{
-		Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+		Level level = new Level(@"<levelXML>
     <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <specials>
         <sp t=""10"" p0=""586"" p1=""5249"" />
@@ -1573,7 +1573,8 @@ public class LevelTest
     <joints>
         <j t=""0"" x=""546"" y=""5223"" b1=""-1"" b2=""s0"" l=""f"" ua=""90"" la=""-90"" m=""f"" tq=""50"" sp=""3"" c=""f""/>
     </joints>
-</levelXML>").ToXML());
+</levelXML>");
+		Assert.IsType<SoccerBall>(level.Joints[0].Second);
 	}
 
 	[Fact]
@@ -1719,7 +1720,7 @@ public class LevelTest
 	public void JointToInvalidEntity()
 	{
 		PinJoint joint = new();
-		Assert.Throws<LevelXMLException>(() => joint.First = joint);
+		joint.First = joint;
 	}
 
 	[Fact]

--- a/tests/LevelTest.cs
+++ b/tests/LevelTest.cs
@@ -98,9 +98,14 @@ public class LevelTest
 	[Fact]
 	public void ParseLevelWithInvalidE()
 	{
-		Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
-    <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""2""/>
-</levelXML>"));
+		string input = @"<levelXML>
+  <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""2"" />
+</levelXML>";
+		Level level = new (input);
+		string expected = @"<levelXML>
+  <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1"" />
+</levelXML>";
+		Assert.Equal(expected, level.ToXML());
 	}
 
 	[Fact]

--- a/tests/LevelTest.cs
+++ b/tests/LevelTest.cs
@@ -167,7 +167,7 @@ public class LevelTest
 	[Fact]
 	public void ParseLevelWithTriggerToSoccerBall()
 	{
-		Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+		Level level = new(@"<levelXML>
     <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <specials>
         <sp t=""10"" p0=""457"" p1=""5199""/>
@@ -177,7 +177,8 @@ public class LevelTest
             <sp i=""0""/>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+		Assert.IsType<SoccerBall>(level.Triggers[0].Targets[0].Targeted);
 	}
 
 	[Fact]
@@ -743,7 +744,7 @@ public class LevelTest
 	[Fact]
 	public void ParseLevelWithInvalidHarpoonActionID()
 	{
-		Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+		Level level = new(@"<levelXML>
     <info v=""1.95"" x=""111"" y=""39"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <specials>
         <sp t=""15"" p0=""121"" p1=""150.0517578125"" p2=""0"" p3=""t"" p4=""t"" p5=""0"" p6=""f"" p7=""f""/>
@@ -755,7 +756,8 @@ public class LevelTest
             </sp>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+		Assert.IsType<FireHarpoon>(level.Triggers[0].Targets[0].Actions[0]);
 	}
 
 	[Fact]
@@ -807,7 +809,7 @@ public class LevelTest
 	[Fact]
 	public void ParseLevelWithInvalidTextBoxActionID()
 	{
-		Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+		Level level= new(@"<levelXML>
     <info v=""1.95"" x=""176"" y=""5138"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <specials>
         <sp t=""16"" p0=""248"" p1=""5152"" p2=""0"" p3=""0"" p4=""2"" p5=""15"" p6=""1"" p8=""100"">
@@ -821,7 +823,8 @@ public class LevelTest
             </sp>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+		Assert.IsType<ChangeOpacity<TextBox>>(level.Triggers[0].Targets[0].Actions[0]);
 	}
 
 	[Fact]
@@ -911,7 +914,7 @@ public class LevelTest
 	[Fact]
 	public void ParseLevelWithInvalidNPCActionID()
 	{
-		Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+		Level level = new(@"<levelXML>
     <info v=""1.95"" x=""214"" y=""5159"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <specials>
         <sp t=""17"" p0=""105"" p1=""117"" p2=""0"" p3=""1"" p4=""f"" p5=""f"" p6=""f"" p7=""t"" p8=""0"" p9=""0"" p10=""0"" p11=""0"" p12=""0"" p13=""0"" p14=""0"" p15=""0"" p16=""0"" p17=""f""/>
@@ -923,7 +926,8 @@ public class LevelTest
             </sp>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+		Assert.IsType<AwakeFromSleep<NonPlayerCharacter>>(level.Triggers[0].Targets[0].Actions[0]);
 	}
 
 	[Fact]
@@ -992,7 +996,7 @@ public class LevelTest
 	[Fact]
 	public void ParseLevelWithInvalidGlassPanelActionID()
 	{
-		Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+		Level level = new(@"<levelXML>
     <info v=""1.95"" x=""214"" y=""5159"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <specials>
         <sp t=""18"" p0=""80"" p1=""105"" p2=""10"" p3=""100"" p4=""0"" p5=""f"" p6=""10"" p7=""t""/>
@@ -1004,7 +1008,8 @@ public class LevelTest
             </sp>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+		Assert.IsType<Shatter>(level.Triggers[0].Targets[0].Actions[0]);
 	}
 
 	[Fact]

--- a/tests/LevelTest.cs
+++ b/tests/LevelTest.cs
@@ -183,15 +183,15 @@ public class LevelTest
 	[Fact]
 	public void ParseLevelWithGroupedSoccerBall()
 	{
-		// I add a ToXML() at the end here as group validity checking should only happen then
-		Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+		Level level = new(@"<levelXML>
     <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <groups>
         <g x=""514"" y=""5321"" r=""0"" ox=""-514"" oy=""-5321"" s=""f"" f=""f"" o=""100"" im=""f"" fr=""f"">
             <sp t=""10"" p0=""385"" p1=""5317""/>
         </g>
     </groups>
-</levelXML>").ToXML());
+</levelXML>");
+		Assert.IsType<SoccerBall>(level.Groups[0].Items[0]);
 	}
 
 	[Fact]

--- a/tests/LevelTest.cs
+++ b/tests/LevelTest.cs
@@ -55,7 +55,7 @@ public class LevelTest
 	public void TestLevelWithNaNCharacter()
 	{
 		Level level = new();
-		Assert.Throws<LevelXMLException>(() => level.Character = double.NaN);
+		level.Character = double.NaN;
 	}
 
 	[Fact]

--- a/tests/LevelsWithTriggerActionsTest.cs
+++ b/tests/LevelsWithTriggerActionsTest.cs
@@ -156,7 +156,7 @@ public class LevelsWithTriggerActionsTest
     [Fact]
     public void ParseLevelWithInvalidShapeActionID()
     {
-        Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+        Level level = new(@"<levelXML>
     <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <shapes>
         <sh t=""0"" p0=""542"" p1=""5338"" p2=""300"" p3=""100"" p4=""0"" p5=""t"" p6=""f"" p7=""1"" p8=""4032711"" p9=""-1"" p10=""100"" p11=""1""/>
@@ -168,7 +168,8 @@ public class LevelsWithTriggerActionsTest
             </sh>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+        Assert.IsType<AwakeFromSleep<Shape>>(level.Triggers[0].Targets[0].Actions[0]);
     }
 
     [Fact]
@@ -195,7 +196,7 @@ public class LevelsWithTriggerActionsTest
     [Fact]
     public void ParseLevelWithInvalidSpecialActionID()
     {
-        Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+        Level level = new(@"<levelXML>
     <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <specials>
         <sp t=""0"" p0=""483"" p1=""5312"" p2=""0"" p3=""f"" p4=""t""/>
@@ -207,7 +208,8 @@ public class LevelsWithTriggerActionsTest
             </sp>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+        Assert.IsType<AwakeFromSleep<Van>>(level.Triggers[0].Targets[0].Actions[0]);
     }
 
     [Fact]
@@ -374,7 +376,7 @@ public class LevelsWithTriggerActionsTest
     [Fact]
     public void ParseLevelWithInvalidGroupActionID()
     {
-        Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+        Level level= new(@"<levelXML>
     <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <groups>
         <g x=""519"" y=""5330"" r=""0"" ox=""-488"" oy=""-5344"" s=""f"" f=""f"" o=""100"" im=""f"" fr=""f"">
@@ -388,7 +390,8 @@ public class LevelsWithTriggerActionsTest
             </g>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+        Assert.IsType<AwakeFromSleep<Group>>(level.Triggers[0].Targets[0].Actions[0]);
     }
 
     [Fact]
@@ -490,7 +493,7 @@ public class LevelsWithTriggerActionsTest
     [Fact]
     public void ParseLevelWithInvalidJointActionID()
     {
-        Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+        Level level = new(@"<levelXML>
     <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <shapes>
         <sh t=""0"" p0=""519"" p1=""5330"" p2=""300"" p3=""100"" p4=""0"" p5=""f"" p6=""f"" p7=""1"" p8=""4032711"" p9=""-1"" p10=""100"" p11=""1""/>
@@ -505,7 +508,8 @@ public class LevelsWithTriggerActionsTest
             </j>
         </t>
     </triggers>
-</levelXML>"));
+</levelXML>");
+        Assert.IsType<DisableMotor>(level.Triggers[0].Targets[0].Actions[0]);
     }
 
     [Fact]
@@ -549,7 +553,7 @@ public class LevelsWithTriggerActionsTest
     [Fact]
     public void ParseLevelWithInvalidTriggerActionID()
     {
-        Assert.Throws<LevelXMLException>(() => new Level(@"<levelXML>
+        Level level = new(@"<levelXML>
     <info v=""1.95"" x=""300"" y=""5100"" c=""1"" f=""f"" h=""f"" bg=""0"" bgc=""16777215"" e=""1""/>
     <triggers>
         <t x=""385"" y=""5170"" w=""100"" h=""100"" a=""0"" b=""1"" t=""1"" r=""1"" sd=""f"" d=""0"">
@@ -559,6 +563,7 @@ public class LevelsWithTriggerActionsTest
         </t>
         <t x=""496"" y=""5325"" w=""100"" h=""100"" a=""0"" b=""1"" t=""1"" r=""1"" sd=""f"" d=""0""/>
     </triggers>
-</levelXML>"));
+</levelXML>");
+        Assert.IsType<Activate>(level.Triggers[0].Targets[0].Actions[0]);
     }
 }

--- a/tests/ShapeTest.cs
+++ b/tests/ShapeTest.cs
@@ -250,12 +250,6 @@ public class ShapeTest
 		Assert.Equal(expectedHeight, art.Height);
 	}
 
-	[Fact]
-	public void ArtTestInvalidXml()
-	{
-		Assert.Throws<LevelXMLException>(() => new Art("<art />"));
-	}
-
 	// Yes, the happy wheels import box also supports this way of formatting vertices.
 	// No idea why, but I'm mad about it.
 	[Fact]

--- a/tests/ShapeTest.cs
+++ b/tests/ShapeTest.cs
@@ -9,17 +9,17 @@ public class ShapeTest
     [Fact]
     public void ShapeMissingX()
     {
-		Assert.Throws<LevelXMLException>(() => new Rectangle(@"<sh t=""0"" p1=""0"" p2=""0""/>"));
+		_ = new Rectangle(@"<sh t=""0"" p1=""0"" p2=""0""/>");
     }
 	[Fact]
 	public void ShapeMissingY()
     {
-		Assert.Throws<LevelXMLException>(() => new Rectangle(@"<sh t=""0"" p0=""0"" p2=""0""/>"));
+		_ = new Rectangle(@"<sh t=""0"" p0=""0"" p2=""0""/>");
     }
 	[Fact]
 	public void ShapeNaNRotation()
     {
-		Assert.Throws<LevelXMLException>(() => new Rectangle(@"<sh t=""0"" p0=""0"" p1=""0"" p4=""NaN""/>"));
+		_ = new Rectangle(@"<sh t=""0"" p0=""0"" p1=""0"" p4=""NaN""/>");
     }
 	[Fact]
 	public void ShapeTestDefaultValues()
@@ -96,13 +96,13 @@ public class ShapeTest
 	[Fact]
 	public void RectangleTestNaNWidth()
 	{
-		Assert.Throws<LevelXMLException>(() => new Rectangle(@"<sh t=""0"" p0=""0"" p1=""0"" p2=""NaN"" />"));
+		_ = new Rectangle(@"<sh t=""0"" p0=""0"" p1=""0"" p2=""NaN"" />");
 	}
 
 	[Fact]
 	public void RectangleTestNaNHeight()
 	{
-		Assert.Throws<LevelXMLException>(() => new Rectangle(@"<sh t=""0"" p0=""0"" p1=""0"" p3=""NaN"" />"));
+		_ = new Rectangle(@"<sh t=""0"" p0=""0"" p1=""0"" p3=""NaN"" />");
 	}
 
 	[Fact]
@@ -138,13 +138,13 @@ public class ShapeTest
 	[Fact]
 	public void TriangleTestNaNWidth()
 	{
-		Assert.Throws<LevelXMLException>(() => new Triangle(@"<sh t=""2"" p0=""0"" p1=""0"" p2=""NaN"" />"));
+		_ = new Triangle(@"<sh t=""2"" p0=""0"" p1=""0"" p2=""NaN"" />");
 	}
 
 	[Fact]
 	public void TriangleTestNaNHeight()
 	{
-		Assert.Throws<LevelXMLException>(() => new Triangle(@"<sh t=""2"" p0=""0"" p1=""0"" p3=""NaN"" />"));
+		_ = new Triangle(@"<sh t=""2"" p0=""0"" p1=""0"" p3=""NaN"" />");
 	}
 
 	[Fact]
@@ -169,13 +169,13 @@ public class ShapeTest
 	[Fact]
 	public void CircleTestNaNWidth()
 	{
-		Assert.Throws<LevelXMLException>(() => new Circle(@"<sh t=""1"" p0=""0"" p1=""0"" p2=""NaN"" />"));
+		_ = new Circle(@"<sh t=""1"" p0=""0"" p1=""0"" p2=""NaN"" />");
 	}
 
 	[Fact]
 	public void CircleTestNaNHeight()
 	{
-		Assert.Throws<LevelXMLException>(() => new Circle(@"<sh t=""1"" p0=""0"" p1=""0"" p3=""NaN"" />"));
+		_ = new Circle(@"<sh t=""1"" p0=""0"" p1=""0"" p3=""NaN"" />");
 	}
 
 	[Fact]

--- a/tests/SoundTriggerTest.cs
+++ b/tests/SoundTriggerTest.cs
@@ -21,7 +21,7 @@ public class SoundTriggerTest
     public void TestSoundIDInvalid()
     {
         SoundTrigger trigger = new();
-        Assert.Throws<LevelXMLException>(() => trigger.Sound = 326);
+        trigger.Sound = 326;
     }
 
     [Fact]

--- a/tests/SpecialTest.cs
+++ b/tests/SpecialTest.cs
@@ -7,13 +7,13 @@ public class SpecialTest
     [Fact]
     public void TestSpecialNaNX()
     {
-        Assert.Throws<LevelXMLException>(() => new TextBox(@"<sp t=""16"" p0=""NaN"" p1=""0"" p2=""0"" p3=""0"" p4=""2"" p5=""15"" p6=""1"" p8=""100"" />"));
+        _ = new TextBox(@"<sp t=""16"" p0=""NaN"" p1=""0"" p2=""0"" p3=""0"" p4=""2"" p5=""15"" p6=""1"" p8=""100"" />");
     }
 
     [Fact]
     public void TestSpecialNaNY()
     {
-        Assert.Throws<LevelXMLException>(() => new TextBox(@"<sp t=""16"" p0=""0"" p1=""NaN"" p2=""0"" p3=""0"" p4=""2"" p5=""15"" p6=""1"" p8=""100"" />"));
+        _ = new TextBox(@"<sp t=""16"" p0=""0"" p1=""NaN"" p2=""0"" p3=""0"" p4=""2"" p5=""15"" p6=""1"" p8=""100"" />");
     }
 
     [Fact]

--- a/tests/SpecialsTests/ArrowGunTest.cs
+++ b/tests/SpecialsTests/ArrowGunTest.cs
@@ -18,6 +18,6 @@ public class ArrowGunTest
     public void TestSettingRotationAsNaN()
     {
         ArrowGun arrowGun = new();
-        Assert.Throws<LevelXMLException>(() => arrowGun.Rotation = double.NaN);
+        arrowGun.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/BladeWeaponTest.cs
+++ b/tests/SpecialsTests/BladeWeaponTest.cs
@@ -19,13 +19,13 @@ public class BladeWeaponTest
     public void TestSettingRotationAsNaN()
     {
         BladeWeapon weapon = new();
-        Assert.Throws<LevelXMLException>(() => weapon.Rotation = double.NaN);
+        weapon.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingWeaponTypeAsNaN()
     {
         BladeWeapon weapon = new();
-        Assert.Throws<LevelXMLException>(() => weapon.WeaponType = double.NaN);
+        weapon.WeaponType = double.NaN;
     }
 }

--- a/tests/SpecialsTests/BoomboxTest.cs
+++ b/tests/SpecialsTests/BoomboxTest.cs
@@ -18,6 +18,6 @@ public class BoomboxTest
     public void TestSettingRotationAsNaN()
     {
         Boombox boombox = new();
-        Assert.Throws<LevelXMLException>(() => boombox.Rotation = double.NaN);
+        boombox.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/BoostTest.cs
+++ b/tests/SpecialsTests/BoostTest.cs
@@ -18,13 +18,13 @@ public class BoostTest
     public void TestSettingRotationAsNaN()
     {
         Boost boost = new();
-        Assert.Throws<LevelXMLException>(() => boost.Rotation = double.NaN);
+        boost.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingPanelsAsNaN()
     {
         Boost boost = new();
-        Assert.Throws<LevelXMLException>(() => boost.Panels = double.NaN);
+        boost.Panels = double.NaN;
     }
 }

--- a/tests/SpecialsTests/BottleTest.cs
+++ b/tests/SpecialsTests/BottleTest.cs
@@ -19,6 +19,6 @@ public class BottleTest
     public void TestSettingRotationAsNaN()
     {
         Bottle bottle = new();
-        Assert.Throws<LevelXMLException>(() => bottle.Rotation = double.NaN);
+        bottle.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/BuildingTest.cs
+++ b/tests/SpecialsTests/BuildingTest.cs
@@ -17,6 +17,6 @@ public class BuildingTest
     public void TestSettingFloorWidthAsNaN()
     {
         BuildingTwo building = new();
-        Assert.Throws<LevelXMLException>(() => building.FloorWidth = double.NaN);
+        building.FloorWidth = double.NaN;
     }
 }

--- a/tests/SpecialsTests/CannonTest.cs
+++ b/tests/SpecialsTests/CannonTest.cs
@@ -21,6 +21,6 @@ public class CannonTest
     public void TestSettingRotationAsNaN()
     {
         Cannon cannon = new();
-        Assert.Throws<LevelXMLException>(() => cannon.Rotation = double.NaN);
+        cannon.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/ChainTest.cs
+++ b/tests/SpecialsTests/ChainTest.cs
@@ -20,20 +20,20 @@ public class ChainTest
     public void TestSettingRotationAsNaN()
     {
         Chain chain = new();
-        Assert.Throws<LevelXMLException>(() => chain.Rotation = double.NaN);
+        chain.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingLinkScaleAsNaN()
     {
         Chain chain = new();
-        Assert.Throws<LevelXMLException>(() => chain.LinkScale = double.NaN);
+        chain.LinkScale = double.NaN;
     }
 
     [Fact]
     public void TestSettingCurveAsNaN()
     {
         Chain chain = new();
-        Assert.Throws<LevelXMLException>(() => chain.Curve = double.NaN);
+        chain.Curve = double.NaN;
     }
 }

--- a/tests/SpecialsTests/ChairTest.cs
+++ b/tests/SpecialsTests/ChairTest.cs
@@ -19,6 +19,6 @@ public class ChairTest
     public void TestSettingRotationAsNaN()
     {
         Chair chair = new();
-        Assert.Throws<LevelXMLException>(() => chair.Rotation = double.NaN);
+        chair.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/DinnerTableTest.cs
+++ b/tests/SpecialsTests/DinnerTableTest.cs
@@ -18,6 +18,6 @@ public class DinnerTableTest
     public void TestSettingRotationAsNaN()
     {
         DinnerTable table = new();
-        Assert.Throws<LevelXMLException>(() => table.Rotation = double.NaN);
+        table.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/FanTest.cs
+++ b/tests/SpecialsTests/FanTest.cs
@@ -16,6 +16,6 @@ public class FanTest
     public void TestSettingRotationAsNaN()
     {
         Fan fan = new();
-        Assert.Throws<LevelXMLException>(() => fan.Rotation = double.NaN);
+        fan.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/FoodTest.cs
+++ b/tests/SpecialsTests/FoodTest.cs
@@ -18,13 +18,13 @@ public class FoodTest
     public void TestSettingRotationAsNaN()
     {
         Food food = new();
-        Assert.Throws<LevelXMLException>(() => food.Rotation = double.NaN);
+        food.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingFoodTypeAsNaN()
     {
         Food food = new();
-        Assert.Throws<LevelXMLException>(() => food.FoodType = double.NaN);
+        food.FoodType = double.NaN;
     }
 }

--- a/tests/SpecialsTests/GlassPanelTest.cs
+++ b/tests/SpecialsTests/GlassPanelTest.cs
@@ -21,20 +21,20 @@ public class GlassPanelTest
     public void TestSettingWidthAsNaN()
     {
         GlassPanel glassPanel = new();
-        Assert.Throws<LevelXMLException>(() => glassPanel.Width = double.NaN);
+        glassPanel.Width = double.NaN;
     }
 
     [Fact]
     public void TestSettingHeightAsNaN()
     {
         GlassPanel glassPanel = new();
-        Assert.Throws<LevelXMLException>(() => glassPanel.Height = double.NaN);
+        glassPanel.Height = double.NaN;
     }
 
     [Fact]
     public void TestSettingRotationAsNaN()
     {
         GlassPanel glassPanel = new();
-        Assert.Throws<LevelXMLException>(() => glassPanel.Rotation = double.NaN);
+        glassPanel.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/HarpoonTest.cs
+++ b/tests/SpecialsTests/HarpoonTest.cs
@@ -21,6 +21,6 @@ public class HarpoonTest
     public void TestSettingRotationAsNaN()
     {
         Harpoon harpoon = new();
-        Assert.Throws<LevelXMLException>(() => harpoon.Rotation = double.NaN);
+        harpoon.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/IBeamTest.cs
+++ b/tests/SpecialsTests/IBeamTest.cs
@@ -20,20 +20,20 @@ public class IBeamTest
     public void TestSettingRotationAsNaN()
     {
         IBeam iBeam = new();
-        Assert.Throws<LevelXMLException>(() => iBeam.Rotation = double.NaN);
+        iBeam.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingWidthAsNaN()
     {
         IBeam iBeam = new();
-        Assert.Throws<LevelXMLException>(() => iBeam.Width = double.NaN);
+        iBeam.Width = double.NaN;
     }
 
     [Fact]
     public void TestSettingHeightAsNaN()
     {
         IBeam iBeam = new();
-        Assert.Throws<LevelXMLException>(() => iBeam.Height = double.NaN);
+        iBeam.Height = double.NaN;
     }
 }

--- a/tests/SpecialsTests/JetTest.cs
+++ b/tests/SpecialsTests/JetTest.cs
@@ -21,13 +21,13 @@ public class JetTest
     public void TestSettingRotationAsNaN()
     {
         Jet jet = new();
-        Assert.Throws<LevelXMLException>(() => jet.Rotation = double.NaN);
+        jet.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingPowerAsNaN()
     {
         Jet jet = new();
-        Assert.Throws<LevelXMLException>(() => jet.Power = double.NaN);
+        jet.Power = double.NaN;
     }
 }

--- a/tests/SpecialsTests/LandmineTest.cs
+++ b/tests/SpecialsTests/LandmineTest.cs
@@ -16,6 +16,6 @@ public class LandmineTest
     public void TestSettingRotationAsNaN()
     {
         Landmine landmine = new();
-        Assert.Throws<LevelXMLException>(() => landmine.Rotation = double.NaN);
+        landmine.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/LogTest.cs
+++ b/tests/SpecialsTests/LogTest.cs
@@ -20,20 +20,20 @@ public class LogTest
     public void TestSettingRotationAsNaN()
     {
         Log log = new();
-        Assert.Throws<LevelXMLException>(() => log.Rotation = double.NaN);
+        log.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingWidthAsNaN()
     {
         Log log = new();
-        Assert.Throws<LevelXMLException>(() => log.Width = double.NaN);
+        log.Width = double.NaN;
     }
 
     [Fact]
     public void TestSettingHeightAsNaN()
     {
         Log log = new();
-        Assert.Throws<LevelXMLException>(() => log.Height = double.NaN);
+        log.Height = double.NaN;
     }
 }

--- a/tests/SpecialsTests/MeteorTest.cs
+++ b/tests/SpecialsTests/MeteorTest.cs
@@ -19,13 +19,13 @@ public class MeteorTest
     public void TestSettingWidthAsNaN()
     {
         Meteor meteor = new();
-        Assert.Throws<LevelXMLException>(() => meteor.Width = double.NaN);
+        meteor.Width = double.NaN;
     }
 
     [Fact]
     public void TestSettingHeightAsNaN()
     {
         Meteor meteor = new();
-        Assert.Throws<LevelXMLException>(() => meteor.Height = double.NaN);
+        meteor.Height = double.NaN;
     }
 }

--- a/tests/SpecialsTests/NonPlayerCharacterTest.cs
+++ b/tests/SpecialsTests/NonPlayerCharacterTest.cs
@@ -30,21 +30,21 @@ public class NonPlayerCharacterTest
     public void TestSettingRotationAsNaN()
     {
         NonPlayerCharacter npc = new();
-        Assert.Throws<LevelXMLException>(() => npc.Rotation = double.NaN);
+        npc.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingPoseAnglesAsNaN()
     {
         NonPlayerCharacter npc = new();
-        Assert.Throws<LevelXMLException>(() => npc.NeckAngle = double.NaN);
-        Assert.Throws<LevelXMLException>(() => npc.FrontArmAngle = double.NaN);
-        Assert.Throws<LevelXMLException>(() => npc.BackArmAngle = double.NaN);
-        Assert.Throws<LevelXMLException>(() => npc.FrontElbowAngle = double.NaN);
-        Assert.Throws<LevelXMLException>(() => npc.BackElbowAngle = double.NaN);
-        Assert.Throws<LevelXMLException>(() => npc.FrontLegAngle = double.NaN);
-        Assert.Throws<LevelXMLException>(() => npc.BackLegAngle = double.NaN);
-        Assert.Throws<LevelXMLException>(() => npc.FrontKneeAngle = double.NaN);
-        Assert.Throws<LevelXMLException>(() => npc.BackKneeAngle = double.NaN);
+        npc.NeckAngle = double.NaN;
+        npc.FrontArmAngle = double.NaN;
+        npc.BackArmAngle = double.NaN;
+        npc.FrontElbowAngle = double.NaN;
+        npc.BackElbowAngle = double.NaN;
+        npc.FrontLegAngle = double.NaN;
+        npc.BackLegAngle = double.NaN;
+        npc.FrontKneeAngle = double.NaN;
+        npc.BackKneeAngle = double.NaN;
     }
 }

--- a/tests/SpecialsTests/PaddlePlatformTest.cs
+++ b/tests/SpecialsTests/PaddlePlatformTest.cs
@@ -19,6 +19,6 @@ public class PaddlePlatformTest
     public void TestSettingRotationAsNaN()
     {
         PaddlePlatform platform = new();
-        Assert.Throws<LevelXMLException>(() => platform.Rotation = double.NaN);
+        platform.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/RailTest.cs
+++ b/tests/SpecialsTests/RailTest.cs
@@ -18,20 +18,20 @@ public class RailTest
     public void TestSettingRotationAsNaN()
     {
         Rail rail = new();
-        Assert.Throws<LevelXMLException>(() => rail.Rotation = double.NaN);
+        rail.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingWidthAsNaN()
     {
         Rail rail = new();
-        Assert.Throws<LevelXMLException>(() => rail.Width = double.NaN);
+        rail.Width = double.NaN;
     }
 
     [Fact]
     public void TestSettingHeightAsNaN()
     {
         Rail rail = new();
-        Assert.Throws<LevelXMLException>(() => rail.Height = double.NaN);
+        rail.Height = double.NaN;
     }
 }

--- a/tests/SpecialsTests/SignTest.cs
+++ b/tests/SpecialsTests/SignTest.cs
@@ -18,6 +18,6 @@ public class SignTest
     public void TestSettingRotationAsNaN()
     {
         Sign sign = new();
-        Assert.Throws<LevelXMLException>(() => sign.Rotation = double.NaN);
+        sign.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/SpikeSetTest.cs
+++ b/tests/SpecialsTests/SpikeSetTest.cs
@@ -19,13 +19,13 @@ public class SpikeSetTest
     public void TestSettingRotationAsNaN()
     {
         SpikeSet spikes = new();
-        Assert.Throws<LevelXMLException>(() => spikes.Rotation = double.NaN);
+        spikes.Rotation = double.NaN;
     }
 
     [Fact]
     public void TestSettingSpikesAsNaN()
     {
         SpikeSet spikes = new();
-        Assert.Throws<LevelXMLException>(() => spikes.Spikes = double.NaN);
+        spikes.Spikes = double.NaN;
     }
 }

--- a/tests/SpecialsTests/SpringPlatformTest.cs
+++ b/tests/SpecialsTests/SpringPlatformTest.cs
@@ -17,6 +17,6 @@ public class SpringPlatformTest
     public void TestSettingRotationAsNaN()
     {
         SpringPlatform springPlatform = new();
-        Assert.Throws<LevelXMLException>(() => springPlatform.Rotation = double.NaN);
+        springPlatform.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/TelevisionTest.cs
+++ b/tests/SpecialsTests/TelevisionTest.cs
@@ -18,6 +18,6 @@ public class TelevisionTest
     public void TestSettingRotationAsNaN()
     {
         Television television = new();
-        Assert.Throws<LevelXMLException>(() => television.Rotation = double.NaN);
+        television.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/TextBoxTest.cs
+++ b/tests/SpecialsTests/TextBoxTest.cs
@@ -22,7 +22,7 @@ public class TextBoxTest
     public void TestNaNRotation()
     {
         TextBox textbox = new();
-        Assert.Throws<LevelXMLException>(() => textbox.Rotation = double.NaN);
+        textbox.Rotation = double.NaN;
     }
 
     [Fact]

--- a/tests/SpecialsTests/ToiletTest.cs
+++ b/tests/SpecialsTests/ToiletTest.cs
@@ -19,6 +19,6 @@ public class ToiletTest
     public void TestSettingRotationAsNaN()
     {
         Toilet toilet = new();
-        Assert.Throws<LevelXMLException>(() => toilet.Rotation = double.NaN);
+        toilet.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/TokenTest.cs
+++ b/tests/SpecialsTests/TokenTest.cs
@@ -15,6 +15,6 @@ public class TokenTest
     public void TestSettingTokenTypeAsNaN()
     {
         Token token = new();
-        Assert.Throws<LevelXMLException>(() => token.TokenType = double.NaN);
+        token.TokenType = double.NaN;
     }
 }

--- a/tests/SpecialsTests/TrashCanTest.cs
+++ b/tests/SpecialsTests/TrashCanTest.cs
@@ -19,6 +19,6 @@ public class TrashCanTest
     public void TestSettingRotationAsNaN()
     {
         TrashCan trashCan = new();
-        Assert.Throws<LevelXMLException>(() => trashCan.Rotation = double.NaN);
+        trashCan.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/VanTest.cs
+++ b/tests/SpecialsTests/VanTest.cs
@@ -17,6 +17,6 @@ public class VanTest
     public void TestSettingRotationAsNaN()
     {
         Van van = new();
-        Assert.Throws<LevelXMLException>(() => van.Rotation = double.NaN);
+        van.Rotation = double.NaN;
     }
 }

--- a/tests/SpecialsTests/WreckingBallTest.cs
+++ b/tests/SpecialsTests/WreckingBallTest.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using System;
 
 namespace LevelXML.Test;
 

--- a/tests/StructsTests/BottleTypeTest.cs
+++ b/tests/StructsTests/BottleTypeTest.cs
@@ -44,6 +44,6 @@ public class BottleTypeTest
     public void BottleTypeAsNaN()
     {
         BottleType bType;
-        Assert.Throws<LevelXMLException>(() => bType = double.NaN);
+        bType = double.NaN;
     }
 }


### PR DESCRIPTION
Got rid of x, y, width, height, rotation NaN throws in shapes (would disappear)
Got rid of x,y NaN throws in specials (would disappear)
Got rid of rotation NaN throw in arrow gun, blade weapon, boombox, boost, bottle, cannon, chain, chair, dinnertable, fan, food, glasspanel, harpoon, ibeam, jet, landmine, log, npc, paddleplatform, rail, sign, spikeset, springplatform, television, textbox, toilet, trashcan, van (would disappear)
Got rid of panels NaN throw in boost (would disappear)
Got rid of floorwidth NaN throw in buildings (would disappear)
Got rid of linkscale and curve NaN throw in chains (would disappear)
Got rid of width and height NaN throws in glass panels, ibeam, log, meteor, rail  (would disappear)
Got rid of power NaN throw in jet (would black hole)
Got rid of any angle NaN throw in npc (would disappear)
Got rid of spikes NaN throw in spikeset (would black hole if non fixed)
Got rid of bottletype Nan Throw (level would not start)
Got rid of character NaN throw (level would not start)
Got rid of foodtype NaN throw (level would not start)
Got rid of tokentype NaN throw (I overlooked this, there's a weird half token thing that I should have kept in the first place)
Got rid of weapontype NaN throw (overlooked also, there's an invisible weapon type)
Never had blackhole warning for wreckingball ropelength
Got rid of angle NaN throw in sliding joint (would black hole attached objects)
Got rid of throw for invalid action number in trigger actions (happy wheels behavior is to default to action 0)
Keeping throw on invalid trigger action as happy wheels behavior is to get rid of it on import
Got rid of throw on invalid trigger target (level would not start)
Got rid of throw on invalid sound id (level would freeze when trigger activates)
Got rid of throw on invalid shape tag name on art (my library can forgive this, just as long we have the parameters needed to construct the shape)
Got rid of throw on invalid E as we can just always set it to 1 anyway.